### PR TITLE
Bump MarkupSafe from 1.0 to 1.1.1 in /frameworks

### DIFF
--- a/frameworks/requirements.txt
+++ b/frameworks/requirements.txt
@@ -4,7 +4,7 @@ Flask-SQLAlchemy==2.1
 Flask-WTF==0.13.1
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 SQLAlchemy==1.2.7
 Werkzeug==0.15.3
 WTForms==2.1


### PR DESCRIPTION
Received the following error while installing requirements. Completed the installation by bumping MarkupSafe to the latest version. 
```ERROR: Command errored out with exit status 1:
     command: /Users/dez/Projects/Bootcamp-Exercises/frameworks/venv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/cs/0_41swv13vd42vp6tfdqbbp40000gn/T/pip-install-62q1cv7w/MarkupSafe/setup.py'"'"'; __file__='"'"'/private/var/folders/cs/0_41swv13vd42vp6tfdqbbp40000gn/T/pip-install-62q1cv7w/MarkupSafe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/cs/0_41swv13vd42vp6tfdqbbp40000gn/T/pip-install-62q1cv7w/MarkupSafe/pip-egg-info
         cwd: /private/var/folders/cs/0_41swv13vd42vp6tfdqbbp40000gn/T/pip-install-62q1cv7w/MarkupSafe/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/cs/0_41swv13vd42vp6tfdqbbp40000gn/T/pip-install-62q1cv7w/MarkupSafe/setup.py", line 6, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature' from 'setuptools' (/Users/dez/Projects/Bootcamp-Exercises/frameworks/venv/lib/python3.7/site-packages/setuptools/__init__.py)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.```